### PR TITLE
Add basic Flutter app wrapper for Zerosei Planet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+ios/
+android/
+web/
+linux/
+macos/
+windows/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Zerosei Planet App
+
+This Flutter project wraps the website [www.zeroseiplanet.it](https://www.zeroseiplanet.it) and adds push notification capabilities for Android and iOS.
+
+## Features
+
+- Displays the website inside a WebView.
+- Push notifications using Firebase Cloud Messaging (FCM).
+- Basic notification settings page.
+
+## Getting Started
+
+1. Install Flutter 3.x and run `flutter pub get`.
+2. Configure Firebase for both Android and iOS:
+   - Follow the official FCM setup guides.
+   - Replace the Firebase configuration files in `android/` and `ios/`.
+3. Run the app with `flutter run`.
+
+### Notification Setup
+
+Notifications use `firebase_messaging` with `flutter_local_notifications` to display alerts when the app is in the foreground. Update Firebase project settings to enable notifications.
+
+## Tests
+
+Basic widget tests are located in `test/`. Run them with:
+
+```bash
+flutter test
+```
+

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,116 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
+  await Firebase.initializeApp();
+}
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
+
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  late final WebViewController _controller;
+  final FlutterLocalNotificationsPlugin _flutterLocalNotificationsPlugin =
+      FlutterLocalNotificationsPlugin();
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeNotifications();
+  }
+
+  Future<void> _initializeNotifications() async {
+    const AndroidInitializationSettings androidSettings =
+        AndroidInitializationSettings('@mipmap/ic_launcher');
+    const InitializationSettings initSettings =
+        InitializationSettings(android: androidSettings);
+    await _flutterLocalNotificationsPlugin.initialize(initSettings);
+
+    FirebaseMessaging messaging = FirebaseMessaging.instance;
+    await messaging.requestPermission();
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      RemoteNotification? notification = message.notification;
+      if (notification != null) {
+        _flutterLocalNotificationsPlugin.show(
+          notification.hashCode,
+          notification.title,
+          notification.body,
+          const NotificationDetails(
+            android: AndroidNotificationDetails(
+              'default_channel',
+              'Default',
+              importance: Importance.max,
+              priority: Priority.high,
+            ),
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Zerosei Planet',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Zerosei Planet')),
+        drawer: Drawer(
+          child: ListView(
+            children: [
+              ListTile(
+                title: const Text('Notification Settings'),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const NotificationSettingsPage()),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+        body: WebViewWidget(
+          controller: WebViewController()
+            ..setJavaScriptMode(JavaScriptMode.unrestricted)
+            ..setNavigationDelegate(
+              NavigationDelegate(
+                onPageFinished: (url) => debugPrint('Page finished loading: $url'),
+              ),
+            )
+            ..loadRequest(Uri.parse('https://www.zeroseiplanet.it')),
+        ),
+      ),
+    );
+  }
+}
+
+class NotificationSettingsPage extends StatelessWidget {
+  const NotificationSettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notification Settings')),
+      body: const Center(
+        child: Text('Configure notifications in system settings.'),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: zeroseiplanet_app
+description: A Flutter wrapper for www.zeroseiplanet.it with push notifications.
+publish_to: "none"
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  webview_flutter: ^4.5.0
+  firebase_core: ^2.15.0
+  firebase_messaging: ^14.7.0
+  flutter_local_notifications: ^16.1.0
+
+flutter:
+  uses-material-design: true

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('dummy test', (WidgetTester tester) async {
+    expect(true, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add minimal Flutter app skeleton using WebView to load `www.zeroseiplanet.it`
- include Firebase-based notification handling and a settings page
- provide project README and gitignore
- include a trivial widget test

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e96d9d8508326bdb38acb71418905